### PR TITLE
Replacing pattern with path in routing

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,6 +1,6 @@
 itlized_social_endpoint:
-    pattern:  /social/auth
+    path:  /social/auth
     defaults: { _controller: ItlizedSocialBundle:Social:auth }
 itlized_social_connect:
-    pattern:  /social/connect/{provider}
+    path:  /social/connect/{provider}
     defaults: { _controller: ItlizedSocialBundle:Social:connect }


### PR DESCRIPTION
"pattern" was replaced by "path" and is deprecated since 2.2 and will be removed in 3.0. See https://github.com/symfony/symfony/pull/6738/files#diff-0
